### PR TITLE
Added warning about CLI appearing to hang if the editor remains open.

### DIFF
--- a/documentation/admin_panel_doc.md
+++ b/documentation/admin_panel_doc.md
@@ -34,7 +34,7 @@ We will also be using the [AWS Amplify](https://aws-amplify.github.io/) library 
            answer: [Int]
        }
        ```
-    1. Save the file you just edited using your text editor.
+    1. Save the file you just edited using your text editor, and close your editor. Otherwise, the Amplify CLI may appear to hang.
 1. Now run `amplify push` to create the backend resources.
     ![AmplifyPushAPI](../.images/AmplifyPushAPI.png)
         The models you defined above create the following on the backend:


### PR DESCRIPTION
*Issue #, if available:*
12
*Description of changes:*
I updated documentation/admin_panel_doc.md to warn the user the Amplify CLI may appear to hang until they close their editor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
