### PR TITLE
Fix client question control anomalies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ In this section we will be subscribing our client to the back end GraphQL API ho
 				answerAvailable: false,
 				questionAvailable: true,
 				modalVisible: true,
-				buttonsDisabled: false
+				buttonsDisabled: false,
+				selectedAnswerButton: null
 			});
 		}
 	})
@@ -99,16 +100,19 @@ Now that our stream is playing and our subscriptions are set up. The last thing 
 1. The first step is to create the view for when a new question is pushed. Paste the following code into the `question` function.
 
 	```javascript
+	let questionId = this.state.question.onCreateQuestion.id;
 	if(this.state.questionAvailable){
 		setTimeout((() => {
 			if(this.state.answerChosen == null){
 				this.answerChosen(-1);
 			}
-			this.setState({
-				modalVisible: false,
-				questionAvailable: false,
-				buttonsDisabled: true,
-				selectedAnswerButton: null
+			if (this.state.question.onCreateQuestion.id == questionId) {
+				this.setState({
+					modalVisible: false,
+					questionAvailable: false,
+					buttonsDisabled: true,
+					selectedAnswerButton: null
+				});
 			});
 		}).bind(this), 10000);
 		return(


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Fix client question control anomalies.

  * Clears the selected response when a new question is posted before the
    current question has timed out. Previously, posting a new question from
    the Admin Panel would change the client UI to show the new question, but
    the previously selected answer (if any) would still be selected. The new
    code defaults the selected answer to null every time a new question is
    posted.
  * Ensure that the question timeout in the client UI does not prematurely
    close new questions. Previously, posting a question from the Admin Panel,
    waiting 7 seconds, then posting a new question, would cause the new
    question to disappear after 3 seconds instead of the full 10 seconds.
    The new code will make a note of the `questionId` being posted, then
    check to make sure the timeout is acting against the same question
    before hiding everything.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.